### PR TITLE
Switch to rpec w/i README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage/*

--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ RedisGraph connects to an active Redis server, defaulting to `host: localhost, p
 These parameters are described fully in the documentation for https://github.com/redis/redis-rb
 
 ## Running tests
-A simple test suite is provided, and can be run with:
-`ruby test/test_suite.rb`
+To ensure prerequisites are installed, run the following:
+`bundle install`
+
 These tests expect a Redis server with the Graph module loaded to be available at localhost:6379
 
+The currently compatible version of the RedisGraph module may be run as follows:
+`docker run -p 6379:6379 -it --rm redislabs/redisgraph:1.2.2`
+
+A simple test suite is provided, and can be run with:
+`rspec`

--- a/lib/redisgraph/connection.rb
+++ b/lib/redisgraph/connection.rb
@@ -10,7 +10,8 @@ class RedisGraph
     redis_version = @connection.info["redis_version"]
     major_version = redis_version.split('.').first.to_i
     raise ServerError, "Redis 4.0 or greater required for RedisGraph support." unless major_version >= 4
-    resp = @connection.call("MODULE", "LIST")
-    raise ServerError, "RedisGraph module not loaded." unless resp.first && resp.first.include?("graph")
+    modules = @connection.call("MODULE", "LIST")
+    module_graph = modules.detect { |_name_key, name, _ver_key, _ver| name == 'graph' }
+    raise ServerError, "RedisGraph module not loaded." if module_graph.nil?
   end
 end


### PR DESCRIPTION
* Add gitignore of (rspec+simplecov) coverage output.
* Modify README to match switch to rspec from the prior
  work to implement circleci.
  * since this version of the client requires a compatible
    version of the server module, add the noted version from issues/1 .
* Modify RedisGraph connection check for the graph module to be
  open to other modules being present (graph is in the module list,
  not strictly the first module).