### PR TITLE
RedisGraph protocol v2 --compact

### DIFF
--- a/lib/redisgraph.rb
+++ b/lib/redisgraph.rb
@@ -14,31 +14,88 @@ class RedisGraph
   def initialize(graph, redis_options = {})
     @graphname = graph
     connect_to_server(redis_options)
+
+    if call_compact?
+      # when call_compact?, labels will be compressed, so require a lookup
+      # table maintained on the client
+
+      # cache semantics around these labels, propertyKeys, and relationshipTypes
+      # defers first read and is invalidated when changed.
+      @labels_proc =  -> { call_procedure('db.labels') }
+      @property_keys_proc = -> { call_procedure('db.propertyKeys') }
+      @relationship_types_proc = -> { call_procedure('db.relationshipTypes') }
+    end
+  end
+
+  def labels
+    @labels ||= @labels_proc.call
+  end
+
+  def property_keys
+    @property_keys ||= @property_keys_proc.call
+  end
+
+  def relationship_types
+    @relationship_types ||= @relationship_types_proc.call
   end
 
   # Execute a command and return its parsed result
   def query(command)
-    begin
-    resp = @connection.call("GRAPH.QUERY", @graphname, command)
-    rescue Redis::CommandError => e
-      raise QueryError, e
+    resp = @connection.call("GRAPH.QUERY", @graphname, command, \
+                            call_compact? ? '--compact' : '')
+    qtype = query_type(command)
+    rs = QueryResult.new(resp,
+                         compact:    call_compact?,
+                         query_type: qtype,
+                         graph:      self)
+    case qtype
+    when :create, :delete
+      @labels = @property_keys = @relationship_types = nil
     end
 
-    QueryResult.new(resp)
+    rs
+  rescue Redis::CommandError => e
+    raise QueryError, e
+  end
+
+  def query_type(command)
+    command_parts = command.split(' ')
+    qtype = command_parts[0].downcase.to_sym
+
+    case qtype
+    when :create, :match
+    else
+      raise QueryError, "Unexpected query type: #{qtype}, supported: CREATE, MATCH"
+    end
+    
+    if qtype == :match
+      if command_parts.detect { |part| part.downcase.to_sym == :delete }
+        qtype = :delete
+      end
+    end
+
+    qtype
   end
 
   # Return the execution plan for a given command
   def explain(command)
-    begin
     resp = @connection.call("GRAPH.EXPLAIN", @graphname, command)
-    rescue Redis::CommandError => e
-      raise QueryError, e
-    end
+    resp = call_compact? ? resp : resp.split("\n")
+  rescue Redis::CommandError => e
+    raise ExplainError, e
   end
 
   # Delete the graph and all associated keys
   def delete
-    resp = @connection.call("GRAPH.DELETE", @graphname)
+    @connection.call("GRAPH.DELETE", @graphname)
+  rescue Redis::CommandError => e
+    raise DeleteError, e
+  end
+
+  def call_procedure(procedure)
+    res = @connection.call("GRAPH.QUERY", @graphname, "CALL #{procedure}()")
+    res[1].flatten
+  rescue Redis::CommandError => e
+    raise CallError, e
   end
 end
-

--- a/lib/redisgraph/connection.rb
+++ b/lib/redisgraph/connection.rb
@@ -1,17 +1,22 @@
 class RedisGraph
   def connect_to_server(options)
     @connection = Redis.new(options)
-    self.verify_module()
+    @module_version = module_version()
+    raise ServerError, "RedisGraph module not loaded." if @module_version.nil?
   end
 
   # Ensure that the connected Redis server supports modules
   # and has loaded the RedisGraph module
-  def verify_module()
+  def module_version()
     redis_version = @connection.info["redis_version"]
     major_version = redis_version.split('.').first.to_i
     raise ServerError, "Redis 4.0 or greater required for RedisGraph support." unless major_version >= 4
     modules = @connection.call("MODULE", "LIST")
     module_graph = modules.detect { |_name_key, name, _ver_key, _ver| name == 'graph' }
-    raise ServerError, "RedisGraph module not loaded." if module_graph.nil?
+    module_graph[3] if module_graph
+  end
+
+  def call_compact?
+    @module_version >= 19900
   end
 end

--- a/lib/redisgraph/errors.rb
+++ b/lib/redisgraph/errors.rb
@@ -1,10 +1,10 @@
 class RedisGraph
-  class RedisGraphError < RuntimeError
-  end
+  class RedisGraphError < RuntimeError; end
 
-  class ServerError < RedisGraphError
-  end
+  class ServerError < RedisGraphError; end
 
-  class QueryError < RedisGraphError
-  end
+  class CallError < RedisGraphError; end
+  class QueryError < RedisGraphError; end
+  class ExplainError < RedisGraphError; end
+  class DeleteError < RedisGraphError; end
 end

--- a/lib/redisgraph/query_result.rb
+++ b/lib/redisgraph/query_result.rb
@@ -3,6 +3,32 @@ class QueryResult
   attr_accessor :resultset
   attr_accessor :stats
 
+  def initialize(response, opts = {})
+    # The response for any query is expected to be a nested array.
+    # If not compact (RedisGraph protocol v1)
+    # The resultset is an array w/ two elements:
+    # 0] Node/Edge key/value pairs as an array w/ two elements:
+    #  0] node/edge names
+    #  1..matches] node/edge values
+    # 1] Statistics as an array of strings
+    #
+    # If compact (RedisGraph protocol v2)
+    # The resultset is an array w/ three elements:
+    # 0] Node/Edge key names w/ the ordinal position used in [1]
+    #    en lieu of the name to compact the result set.
+    # 1] Node/Edge key/value pairs as an array w/ two elements:
+    #  0] node/edge name id from [0]
+    #  1..matches] node/edge values
+    # 2] Statistics as an array of strings
+    #
+    @compact = opts[:compact]
+    @query_type = opts[:query_type]
+    @graph = opts[:graph]
+
+    @resultset = parse_resultset(response)
+    @stats = parse_stats(response)
+  end
+
   def print_resultset
     pretty = Terminal::Table.new headings: columns do |t|
       resultset.each { |record| t << record }
@@ -11,6 +37,11 @@ class QueryResult
   end
 
   def parse_resultset(response)
+    meth = @compact ? :parse_resultset_v2 : :parse_resultset_v1
+    send(meth, response)
+  end
+
+  def parse_resultset_v1(response)
     # Any non-empty result set will have multiple rows (arrays)
     return nil unless response[0].length > 1
     # First row is return elements / properties
@@ -19,13 +50,77 @@ class QueryResult
     @resultset = response[0]
   end
 
+  def parse_resultset_v2(response)
+    # In the v2 protocol, CREATE does not contain an empty row preceding statistics
+    case @query_type
+    when :create, :delete
+      return
+    end
+
+    # Any non-empty result set will have multiple rows (arrays)
+    return nil unless response[0].length > 1
+
+    property_keys = @graph.property_keys
+
+    # First row is header describing the returned records, corresponding
+    # precisely in order and naming to the RETURN clause of the query.
+    header = response[0].map { |_type, el| el }.to_a
+
+    @columns = header.reduce([]) do |agg, it|
+      if it.include?('.')
+        agg << it
+      else
+        property_keys.each do |pkey|
+          agg << "#{it}.#{pkey}"
+        end
+      end
+      agg
+    end
+
+    # TODO: add handling for encountering an id for propertyKey that is out of
+    # the cached set. this currently works for the test cases and generally for
+    # A. a single client, on changing the schema the cache is invalidated.
+    # B. a graph that has the schema relatively static, so cache remains coherent
+
+    # Second row is the actual data returned by the query
+    data = response[1].map do |row|
+      src, dest = row
+      src_props = src[2].sort_by { |it| it[0] }.map { |props| props[2] }
+      dest_props = dest[2].sort_by { |it| it[0] }.map { |props| props[2] }
+      src_props + dest_props
+    end
+
+    data
+  end
+
   # Read metrics about internal query handling
   def parse_stats(response)
+    meth = @compact ? :parse_stats_v2 : :parse_stats_v1
+    send(meth, response)
+  end
+
+  def parse_stats_v2(response)
+    # In the v2 protocol, CREATE does not contain an empty row preceding statistics
+    stats_offset = case @query_type
+                when :create, :delete then 0
+                when :match then 2
+                end
+
+    return nil unless response[stats_offset]
+
+    parse_stats_row(response[stats_offset])
+  end
+
+  def parse_stats_v1(response)
     return nil unless response[1]
 
+    parse_stats_row(response[1])
+  end
+
+  def parse_stats_row(response_row)
     stats = {}
 
-    response[1].each do |stat|
+    response_row.each do |stat|
       line = stat.split(': ')
       val = line[1].split(' ')[0]
 
@@ -48,12 +143,4 @@ class QueryResult
     end
     stats
   end
-
-  def initialize(response)
-    # The response for any query is expected to be a nested array.
-    # The only top-level values will be the result set and the statistics.
-    @resultset = parse_resultset(response)
-    @stats = parse_stats(response)
-  end
 end
-


### PR DESCRIPTION
* Maintain support for RedisGraph protocol v1.
* Add support for RedisGraph protocol v2.
  * locally cache labels, relationshipTypes, propertyKeys.
  * use --compact form for all graph queries.

Should help w/, if not fully address, #1 